### PR TITLE
Migrate to Quarkus 3 and Java 17

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -14,7 +14,7 @@ components:
     id: redhat/vscode-openshift-connector/latest
   - type: dockerimage
     alias: maven
-    image: 'registry.redhat.io/codeready-workspaces/plugin-java11-rhel8@sha256:641e223f5efbc32bab3461aa000e3a50a5dcca063331322158d1c959129ffd99'
+    image: 'registry.redhat.io/devspaces/udi-rhel8@sha256:b1f112760b2640b5e8612869536a000612837e8e247c74d3d99e9fcfbc56d2f3'
     env:
       - name: JAVA_OPTS
         value: '-XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom -Duser.home=/home/jboss'

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.8.1</quarkus.platform.version>
+    <quarkus.platform.version>3.8.2</quarkus.platform.version>
     <surefire-plugin.version>3.2.3</surefire-plugin.version>
     <webjars-bootstrap.version>5.1.3</webjars-bootstrap.version>
     <webjars-font-awesome.version>4.7.0</webjars-font-awesome.version>

--- a/pom.xml
+++ b/pom.xml
@@ -8,8 +8,8 @@
   <properties>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.1.3.Final</quarkus.platform.version>
+    <quarkus.platform.version>3.2.2.Final</quarkus.platform.version>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
     <webjars-bootstrap.version>5.1.3</webjars-bootstrap.version>
     <webjars-font-awesome.version>4.7.0</webjars-font-awesome.version>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.16.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>3.1.3.Final</quarkus.platform.version>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
     <webjars-bootstrap.version>5.1.3</webjars-bootstrap.version>
     <webjars-font-awesome.version>4.7.0</webjars-font-awesome.version>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.7.4</quarkus.platform.version>
+    <quarkus.platform.version>3.8.1</quarkus.platform.version>
     <surefire-plugin.version>3.2.3</surefire-plugin.version>
     <webjars-bootstrap.version>5.1.3</webjars-bootstrap.version>
     <webjars-font-awesome.version>4.7.0</webjars-font-awesome.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <artifactId>quarkus-petclinic</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <properties>
-    <compiler-plugin.version>3.8.1</compiler-plugin.version>
+    <compiler-plugin.version>3.12.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
@@ -14,8 +14,8 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>3.2.2.Final</quarkus.platform.version>
-    <surefire-plugin.version>2.22.1</surefire-plugin.version>
+    <quarkus.platform.version>3.7.4</quarkus.platform.version>
+    <surefire-plugin.version>3.2.3</surefire-plugin.version>
     <webjars-bootstrap.version>5.1.3</webjars-bootstrap.version>
     <webjars-font-awesome.version>4.7.0</webjars-font-awesome.version>
   </properties>

--- a/src/main/docker/Dockerfile.fast-jar
+++ b/src/main/docker/Dockerfile.fast-jar
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/src/main/docker/Dockerfile.jvm
+++ b/src/main/docker/Dockerfile.jvm
@@ -23,7 +23,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
 
-ARG JAVA_PACKAGE=java-11-openjdk-headless
+ARG JAVA_PACKAGE=java-17-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script

--- a/src/main/java/org/quarkus/samples/petclinic/JaxRsApplication.java
+++ b/src/main/java/org/quarkus/samples/petclinic/JaxRsApplication.java
@@ -1,7 +1,7 @@
 package org.quarkus.samples.petclinic;
 
 import io.smallrye.common.annotation.Blocking;
-import javax.ws.rs.core.Application;
+import jakarta.ws.rs.core.Application;
 
 /**
  * Used to ensure that all endpoints are blocking by default

--- a/src/main/java/org/quarkus/samples/petclinic/model/Person.java
+++ b/src/main/java/org/quarkus/samples/petclinic/model/Person.java
@@ -1,9 +1,9 @@
 package org.quarkus.samples.petclinic.model;
 
-import javax.persistence.Column;
-import javax.persistence.MappedSuperclass;
-import javax.validation.constraints.NotEmpty;
-import javax.ws.rs.FormParam;
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.ws.rs.FormParam;
 
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
 

--- a/src/main/java/org/quarkus/samples/petclinic/owner/LocalDateConverter.java
+++ b/src/main/java/org/quarkus/samples/petclinic/owner/LocalDateConverter.java
@@ -2,7 +2,7 @@ package org.quarkus.samples.petclinic.owner;
 
 import java.time.LocalDate;
 
-import javax.ws.rs.ext.ParamConverter;
+import jakarta.ws.rs.ext.ParamConverter;
 
 public class LocalDateConverter implements ParamConverter<LocalDate> {
 

--- a/src/main/java/org/quarkus/samples/petclinic/owner/LocalDateParamConverterProvider.java
+++ b/src/main/java/org/quarkus/samples/petclinic/owner/LocalDateParamConverterProvider.java
@@ -1,8 +1,8 @@
 package org.quarkus.samples.petclinic.owner;
 
-import javax.ws.rs.ext.ParamConverter;
-import javax.ws.rs.ext.ParamConverterProvider;
-import javax.ws.rs.ext.Provider;
+import jakarta.ws.rs.ext.ParamConverter;
+import jakarta.ws.rs.ext.ParamConverterProvider;
+import jakarta.ws.rs.ext.Provider;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.time.LocalDate;

--- a/src/main/java/org/quarkus/samples/petclinic/owner/Owner.java
+++ b/src/main/java/org/quarkus/samples/petclinic/owner/Owner.java
@@ -4,15 +4,15 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.OneToMany;
-import javax.persistence.Table;
-import javax.validation.constraints.Digits;
-import javax.validation.constraints.NotEmpty;
-import javax.ws.rs.FormParam;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.ws.rs.FormParam;
 
 import org.quarkus.samples.petclinic.model.Person;
 

--- a/src/main/java/org/quarkus/samples/petclinic/owner/OwnerForm.java
+++ b/src/main/java/org/quarkus/samples/petclinic/owner/OwnerForm.java
@@ -1,6 +1,6 @@
 package org.quarkus.samples.petclinic.owner;
 
-import javax.ws.rs.FormParam;
+import jakarta.ws.rs.FormParam;
 
 public class OwnerForm {
     

--- a/src/main/java/org/quarkus/samples/petclinic/owner/OwnersResource.java
+++ b/src/main/java/org/quarkus/samples/petclinic/owner/OwnersResource.java
@@ -10,18 +10,18 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import javax.inject.Inject;
-import javax.transaction.Transactional;
-import javax.validation.ConstraintViolation;
-import javax.validation.Validator;
-import javax.ws.rs.BeanParam;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
 
 import io.quarkus.qute.TemplateInstance;
 

--- a/src/main/java/org/quarkus/samples/petclinic/owner/Pet.java
+++ b/src/main/java/org/quarkus/samples/petclinic/owner/Pet.java
@@ -9,13 +9,13 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
-import javax.persistence.Transient;
-import javax.validation.constraints.NotEmpty;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+import jakarta.validation.constraints.NotEmpty;
 
 import org.quarkus.samples.petclinic.visit.Visit;
 

--- a/src/main/java/org/quarkus/samples/petclinic/owner/PetResource.java
+++ b/src/main/java/org/quarkus/samples/petclinic/owner/PetResource.java
@@ -9,17 +9,17 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import javax.inject.Inject;
-import javax.transaction.Transactional;
-import javax.validation.ConstraintViolation;
-import javax.validation.Validator;
-import javax.ws.rs.FormParam;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 import io.quarkus.qute.TemplateInstance;
 

--- a/src/main/java/org/quarkus/samples/petclinic/owner/PetType.java
+++ b/src/main/java/org/quarkus/samples/petclinic/owner/PetType.java
@@ -2,9 +2,9 @@ package org.quarkus.samples.petclinic.owner;
 
 import java.util.Collection;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
 
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
 import io.quarkus.qute.TemplateExtension;

--- a/src/main/java/org/quarkus/samples/petclinic/owner/VisitResource.java
+++ b/src/main/java/org/quarkus/samples/petclinic/owner/VisitResource.java
@@ -8,17 +8,17 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import javax.inject.Inject;
-import javax.transaction.Transactional;
-import javax.validation.ConstraintViolation;
-import javax.validation.Validator;
-import javax.ws.rs.BeanParam;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 import io.quarkus.qute.TemplateInstance;
 

--- a/src/main/java/org/quarkus/samples/petclinic/system/CrashResource.java
+++ b/src/main/java/org/quarkus/samples/petclinic/system/CrashResource.java
@@ -1,9 +1,9 @@
 package org.quarkus.samples.petclinic.system;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 @Path("/oups")
 public class CrashResource {

--- a/src/main/java/org/quarkus/samples/petclinic/system/ErrorExceptionMapper.java
+++ b/src/main/java/org/quarkus/samples/petclinic/system/ErrorExceptionMapper.java
@@ -1,7 +1,7 @@
 package org.quarkus.samples.petclinic.system;
 
-import javax.inject.Inject;
-import javax.ws.rs.core.Response;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
 

--- a/src/main/java/org/quarkus/samples/petclinic/system/LocaleVariantCreator.java
+++ b/src/main/java/org/quarkus/samples/petclinic/system/LocaleVariantCreator.java
@@ -3,7 +3,7 @@ package org.quarkus.samples.petclinic.system;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MediaType;
 
 import io.quarkus.qute.Variant;
 

--- a/src/main/java/org/quarkus/samples/petclinic/system/TemplatesLocale.java
+++ b/src/main/java/org/quarkus/samples/petclinic/system/TemplatesLocale.java
@@ -1,6 +1,6 @@
 package org.quarkus.samples.petclinic.system;
 
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 
 import java.util.Collection;
 import java.util.List;

--- a/src/main/java/org/quarkus/samples/petclinic/system/WelcomeResource.java
+++ b/src/main/java/org/quarkus/samples/petclinic/system/WelcomeResource.java
@@ -2,11 +2,11 @@ package org.quarkus.samples.petclinic.system;
 
 import java.util.Locale;
 
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 import io.quarkus.qute.TemplateInstance;
 

--- a/src/main/java/org/quarkus/samples/petclinic/vet/Specialty.java
+++ b/src/main/java/org/quarkus/samples/petclinic/vet/Specialty.java
@@ -1,8 +1,8 @@
 package org.quarkus.samples.petclinic.vet;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
 
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
 

--- a/src/main/java/org/quarkus/samples/petclinic/vet/Vet.java
+++ b/src/main/java/org/quarkus/samples/petclinic/vet/Vet.java
@@ -6,12 +6,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.JoinTable;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToMany;
-import javax.persistence.Table;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.Table;
 
 import org.quarkus.samples.petclinic.model.Person;
 

--- a/src/main/java/org/quarkus/samples/petclinic/vet/VetResource.java
+++ b/src/main/java/org/quarkus/samples/petclinic/vet/VetResource.java
@@ -7,11 +7,11 @@ import io.quarkus.qute.TemplateInstance;
 
 import java.util.List;
 
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 @Path("/")
 public class VetResource {

--- a/src/main/java/org/quarkus/samples/petclinic/vet/Vets.java
+++ b/src/main/java/org/quarkus/samples/petclinic/vet/Vets.java
@@ -3,7 +3,7 @@ package org.quarkus.samples.petclinic.vet;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElement;
 
 public class Vets {
     

--- a/src/main/java/org/quarkus/samples/petclinic/visit/Visit.java
+++ b/src/main/java/org/quarkus/samples/petclinic/visit/Visit.java
@@ -3,11 +3,11 @@ package org.quarkus.samples.petclinic.visit;
 import java.time.LocalDate;
 import java.util.Collection;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Table;
-import javax.validation.constraints.NotEmpty;
-import javax.ws.rs.FormParam;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.ws.rs.FormParam;
 
 import io.quarkus.hibernate.orm.panache.PanacheEntity;
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,6 +20,3 @@ quarkus.kubernetes.service-type=load-balancer
 quarkus.http.enable-compression=true
 quarkus.http.enable-decompression=true
 quarkus.qute.strict-rendering=true
-
-quarkus.index-dependency.jakarta-ws-rs-api.group-id=jakarta.ws.rs
-quarkus.index-dependency.jakarta-ws-rs-api.artifact-id=jakarta.ws.rs-api

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,3 +20,6 @@ quarkus.kubernetes.service-type=load-balancer
 quarkus.http.enable-compression=true
 quarkus.http.enable-decompression=true
 quarkus.qute.strict-rendering=true
+
+quarkus.index-dependency.jakarta-ws-rs-api.group-id=jakarta.ws.rs
+quarkus.index-dependency.jakarta-ws-rs-api.artifact-id=jakarta.ws.rs-api

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -9,11 +9,11 @@ INSERT INTO specialties VALUES (1001, 'radiology');
 INSERT INTO specialties VALUES (1002, 'surgery');
 INSERT INTO specialties VALUES (1003, 'dentistry');
 
-INSERT INTO vet_specialties VALUES (1002, 1001);
-INSERT INTO vet_specialties VALUES (1003, 1002);
+INSERT INTO vet_specialties VALUES (1001, 1002);
+INSERT INTO vet_specialties VALUES (1002, 1003);
 INSERT INTO vet_specialties VALUES (1003, 1003);
-INSERT INTO vet_specialties VALUES (1004, 1002);
-INSERT INTO vet_specialties VALUES (1005, 1001);
+INSERT INTO vet_specialties VALUES (1002, 1004);
+INSERT INTO vet_specialties VALUES (1001, 1005);
 
 INSERT INTO types VALUES (1001, 'cat');
 INSERT INTO types VALUES (1002, 'dog');


### PR DESCRIPTION
This PR migrates the Quarkus Petclinic to Quarkus 3 and Java 17.

I did the Quarkus 3 upgrade with the `quarkus-maven-plugin`. Afterwards, I was facing the following build error:

```text
Caused by: io.quarkus.builder.BuildException: 
Build failure: Build failed due to errors
	[error]: Build step io.quarkus.rest.client.reactive.deployment.RestClientReactiveProcessor#addRestClientBeans threw an exception: java.lang.RuntimeException: The class jakarta.ws.rs.core.Application is not inside the Jandex index
	at org.jboss.resteasy.reactive.common.processor.JandexUtil.isImplementorOf(JandexUtil.java:397)
	at io.quarkus.rest.client.reactive.deployment.RestClientReactiveProcessor.addRestClientBeans(RestClientReactiveProcessor.java:526)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at io.quarkus.deployment.ExtensionLoader$3.execute(ExtensionLoader.java:909)
	at io.quarkus.builder.BuildContext.run(BuildContext.java:282)
	at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
	at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2513)
	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1538)
	at java.base/java.lang.Thread.run(Thread.java:833)
	at org.jboss.threads.JBossThread.run(JBossThread.java:501)
```

Which is why I added a `quarkus.index-dependency` entry for `jakarta.ws.rs:jakarta.ws.rs-api`.

For the Java 17 upgrade, I only modified the `pom.xml` so far. There are still these Java 11 references:

1. https://github.com/redhat-developer-demos/quarkus-petclinic/blob/master/devfile.yaml#L17
2. https://github.com/redhat-developer-demos/quarkus-petclinic/blob/master/src/main/docker/Dockerfile.jvm#L26
3. https://github.com/redhat-developer-demos/quarkus-petclinic/blob/master/src/main/docker/Dockerfile.fast-jar#L26

Unfortunately, I'm not quite sure which (Red Hat) images / packages to use for Java 17. Therefore, I marked this PR as a draft.